### PR TITLE
Update to node 16 and use environment files instead of set-output

### DIFF
--- a/.github/workflows/macos_test_command_output.yml
+++ b/.github/workflows/macos_test_command_output.yml
@@ -8,8 +8,8 @@ jobs:
   PASSED-assert-file:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -18,8 +18,8 @@ jobs:
   FAILED-assert-file:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -28,8 +28,8 @@ jobs:
   PASSED-specific-line:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -39,8 +39,8 @@ jobs:
   FAILED-specific-line:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -50,8 +50,8 @@ jobs:
   PASSED-contains:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: runner
@@ -60,8 +60,8 @@ jobs:
   FAILED-contains:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: error

--- a/.github/workflows/macos_test_command_output.yml
+++ b/.github/workflows/macos_test_command_output.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -29,7 +29,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -51,7 +51,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: runner
@@ -61,7 +61,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: error

--- a/.github/workflows/macos_test_command_output_v1.yml
+++ b/.github/workflows/macos_test_command_output_v1.yml
@@ -8,10 +8,10 @@ jobs:
   PASSED-assert-file:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: cat action.yml
@@ -21,23 +21,23 @@ jobs:
   FAILED-assert-file:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
           expected_result: FAILED
-  
+
   PASSED-specific-line:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: cat action.yml
@@ -48,10 +48,10 @@ jobs:
   FAILED-specific-line:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha
@@ -62,7 +62,7 @@ jobs:
   PASSED-contains:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha
@@ -72,7 +72,7 @@ jobs:
   FAILED-contains:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha

--- a/.github/workflows/ubuntu_test_command_output.yml
+++ b/.github/workflows/ubuntu_test_command_output.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: runner
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: error

--- a/.github/workflows/ubuntu_test_command_output.yml
+++ b/.github/workflows/ubuntu_test_command_output.yml
@@ -8,8 +8,8 @@ jobs:
   PASSED-assert-file:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -18,8 +18,8 @@ jobs:
   FAILED-assert-file:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -28,8 +28,8 @@ jobs:
   PASSED-specific-line:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -39,8 +39,8 @@ jobs:
   FAILED-specific-line:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -50,8 +50,8 @@ jobs:
   PASSED-contains:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: runner
@@ -60,8 +60,8 @@ jobs:
   FAILED-contains:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: error

--- a/.github/workflows/ubuntu_test_command_output_v1.yml
+++ b/.github/workflows/ubuntu_test_command_output_v1.yml
@@ -8,10 +8,10 @@ jobs:
   PASSED-assert-file:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: cat action.yml
@@ -21,10 +21,10 @@ jobs:
   FAILED-assert-file:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha
@@ -34,10 +34,10 @@ jobs:
   PASSED-specific-line:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: cat action.yml
@@ -48,10 +48,10 @@ jobs:
   FAILED-specific-line:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha
@@ -62,7 +62,7 @@ jobs:
   PASSED-contains:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha
@@ -72,7 +72,7 @@ jobs:
   FAILED-contains:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha

--- a/.github/workflows/windows_test_command_output.yml
+++ b/.github/workflows/windows_test_command_output.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -29,7 +29,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -51,7 +51,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: runner
@@ -61,7 +61,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ajantsch/assert-command-line-output@main
+      - uses: GuillaumeFalourd/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: error

--- a/.github/workflows/windows_test_command_output.yml
+++ b/.github/workflows/windows_test_command_output.yml
@@ -8,8 +8,8 @@ jobs:
   PASSED-assert-file:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -18,8 +18,8 @@ jobs:
   FAILED-assert-file:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -28,8 +28,8 @@ jobs:
   PASSED-specific-line:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -39,8 +39,8 @@ jobs:
   FAILED-specific-line:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -50,8 +50,8 @@ jobs:
   PASSED-contains:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: runner
@@ -60,8 +60,8 @@ jobs:
   FAILED-contains:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@main
+      - uses: actions/checkout@v3
+      - uses: ajantsch/assert-command-line-output@main
         with:
           command_line: ls -lha
           contains: error

--- a/.github/workflows/windows_test_command_output_v1.yml
+++ b/.github/workflows/windows_test_command_output_v1.yml
@@ -8,10 +8,10 @@ jobs:
   PASSED-assert-file:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: cat action.yml
@@ -21,10 +21,10 @@ jobs:
   FAILED-assert-file:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha
@@ -34,10 +34,10 @@ jobs:
   PASSED-specific-line:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: cat action.yml
@@ -48,10 +48,10 @@ jobs:
   FAILED-specific-line:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: 16
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha
@@ -62,7 +62,7 @@ jobs:
   PASSED-contains:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha
@@ -72,7 +72,7 @@ jobs:
   FAILED-contains:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: GuillaumeFalourd/test-cli-commands-action@v1
         with:
           command_line: ls -lha

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Github Action to assert / check a command line output 🕵️⚙️🖥
 
 This action allows to compare a _command line output_ (success or error) with a _file content_ located on the repository, or to check if it contains a specific _expression_.
 
-* * *
+---
 
 ## 📚 Usage
 
@@ -22,11 +22,11 @@ This action allows to compare a _command line output_ (success or error) with a 
 
 ### Requirements
 
-⚠️    The [`actions/checkout`](https://github.com/marketplace/actions/checkout) is mandatory to use this action, as it will be necessary to access the repository files, or to access the command line output file after the action execution.
+⚠️ The [`actions/checkout`](https://github.com/marketplace/actions/checkout) is mandatory to use this action, as it will be necessary to access the repository files, or to access the command line output file after the action execution.
 
-☞ *Note: This action gathers the logic from the [command-output-file-action](https://github.com/GuillaumeFalourd/command-output-file-action) and the [diff-action](https://github.com/GuillaumeFalourd/diff-action)*.
+☞ _Note: This action gathers the logic from the [command-output-file-action](https://github.com/GuillaumeFalourd/command-output-file-action) and the [diff-action](https://github.com/GuillaumeFalourd/diff-action)_.
 
- * * *
+---
 
 ## ♻️ Scenarios
 
@@ -35,25 +35,25 @@ This action allows to compare a _command line output_ (success or error) with a 
 #### Expecting command output to be EQUAL to `assert.txt` file content
 
 ```yaml
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@v2
-        with:
-          command_line: ls -lha
-          assert_file_path: path/to/assert.txt
-          expected_result: PASSED
+steps:
+  - uses: actions/checkout@v3
+  - uses: GuillaumeFalourd/assert-command-line-output@v2
+    with:
+      command_line: ls -lha
+      assert_file_path: path/to/assert.txt
+      expected_result: PASSED
 ```
 
 #### Expecting command output to be DIFFERENT than the `assert.txt` file content
 
 ```yaml
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@v2
-        with:
-          command_line: ls -lha
-          assert_file_path: path/to/assert.txt
-          expected_result: FAILED
+steps:
+  - uses: actions/checkout@v3
+  - uses: GuillaumeFalourd/assert-command-line-output@v2
+    with:
+      command_line: ls -lha
+      assert_file_path: path/to/assert.txt
+      expected_result: FAILED
 ```
 
 ### `2️⃣ Assert specific file line`
@@ -61,27 +61,27 @@ This action allows to compare a _command line output_ (success or error) with a 
 #### Expecting command output line 3 to be EQUAL than the `assert.txt` file content in line 3
 
 ```yaml
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@v2
-        with:
-          command_line: ls -lha
-          assert_file_path: path/to/assert.txt
-          expected_result: PASSED
-          specific_line: 3
+steps:
+  - uses: actions/checkout@v3
+  - uses: GuillaumeFalourd/assert-command-line-output@v2
+    with:
+      command_line: ls -lha
+      assert_file_path: path/to/assert.txt
+      expected_result: PASSED
+      specific_line: 3
 ```
 
 #### Expecting command output line 3 to be DIFFERENT than the `assert.txt` file content in line 3
 
 ```yaml
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@v2
-        with:
-          command_line: ls -lha
-          assert_file_path: path/to/assert.txt
-          expected_result: FAILED
-          specific_line: 3
+steps:
+  - uses: actions/checkout@v3
+  - uses: GuillaumeFalourd/assert-command-line-output@v2
+    with:
+      command_line: ls -lha
+      assert_file_path: path/to/assert.txt
+      expected_result: FAILED
+      specific_line: 3
 ```
 
 ### `3️⃣ Assert specific expression`
@@ -89,51 +89,52 @@ This action allows to compare a _command line output_ (success or error) with a 
 #### Expecting command output to contain specific expression
 
 ```yaml
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@v2
-        with:
-          command_line: ls -lha
-          contains: runner
-          expected_result: PASSED
+steps:
+  - uses: actions/checkout@v3
+  - uses: GuillaumeFalourd/assert-command-line-output@v2
+    with:
+      command_line: ls -lha
+      contains: runner
+      expected_result: PASSED
 ```
 
 #### Expecting command output NOT to contain specific expression
 
 ```yaml
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: GuillaumeFalourd/assert-command-line-output@v2
-        with:
-          command_line: ls -lha
-          contains: error
-          expected_result: FAILED
+steps:
+  - uses: actions/checkout@v3
+  - uses: GuillaumeFalourd/assert-command-line-output@v2
+    with:
+      command_line: ls -lha
+      contains: error
+      expected_result: FAILED
 ```
 
-* * *
+---
 
 ## ▶️ Action Inputs
 
-Field | Mandatory | Observation
------------- | ------------  | -------------
-**command_line** | YES | Command Line to assert / check. <br/> _e.g: `ls -lha`_
-**assert_file_path** | NO | Path to assert file that will be compared to command line output. <br/> _e.g: `path/to/assert.txt`_
-**specific_line** | NO | Specific line to check from output file with assert file. <br/> **NEEDS** `assert_file_path` configured. <br/> _e.g: `1` (*integer value only*)_
-**contains** | NO | String expression to check on the command line output. <br/> _e.g: `string expression`_
-**expected_result** | NO | Expected assert output. <br/> _e.g: `PASSED` (*default*) or `FAILED`_
+| Field                | Mandatory | Observation                                                                                                                                      |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **command_line**     | YES       | Command Line to assert / check. <br/> _e.g: `ls -lha`_                                                                                           |
+| **assert_file_path** | NO        | Path to assert file that will be compared to command line output. <br/> _e.g: `path/to/assert.txt`_                                              |
+| **specific_line**    | NO        | Specific line to check from output file with assert file. <br/> **NEEDS** `assert_file_path` configured. <br/> _e.g: `1` (*integer value only*)_ |
+| **contains**         | NO        | String expression to check on the command line output. <br/> _e.g: `string expression`_                                                          |
+| **expected_result**  | NO        | Expected assert output. <br/> _e.g: `PASSED` (*default*) or `FAILED`_                                                                            |
 
 ### 🔎 Good to know
 
 - At least **one type of assert** between `contains`, `specific_line` and `assert_file_path` has to be configured.
 
 - If **more than one type of assert** is set, the priority between them is:
+
   - 1️⃣ `contains`
   - 2️⃣ `specific_line`
   - 3️⃣ `assert_file_path`
 
 - You can access the **output.txt file** in the repository directory **after running the action**.
 
-* * *
+---
 
 ## 🤝 Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,10 @@ runs:
   using: "composite"
   steps:
     - name: Setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: '14'
-        
+        node-version: '16'
+
     - name: install strip-ansi-cli
       run: |
         if [ -z "${{ inputs.contains }}" ]; then

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
                 result=$(echo "FAILED")
             fi
         fi
-        echo "::set-output name=result::$(echo $result)"
+        echo "{result}={$(echo $result)}" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: GOT vs EXPECTED


### PR DESCRIPTION
This PR fixes two warnings/deprecations:

- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/