### PR TITLE
Adding work_dir input

### DIFF
--- a/.github/workflows/macos_test_command_output_feature.yml
+++ b/.github/workflows/macos_test_command_output_feature.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+      - uses: pedroaston/assert-command-line-output@workdir_feature
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+      - uses: pedroaston/assert-command-line-output@workdir_feature
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -29,7 +29,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+      - uses: pedroaston/assert-command-line-output@workdir_feature
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+      - uses: pedroaston/assert-command-line-output@workdir_feature
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -51,7 +51,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+      - uses: pedroaston/assert-command-line-output@workdir_feature
         with:
           command_line: ls -lha
           contains: runner
@@ -61,7 +61,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+      - uses: pedroaston/assert-command-line-output@workdir_feature
         with:
           command_line: ls -lha
           contains: error
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: mkdir abc
       - run: echo "Hello World" > abc/def.txt
-      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+      - uses: pedroaston/assert-command-line-output@workdir_feature
         with:
           command_line: cat def.txt
           contains: Hello
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: mkdir abc
       - run: echo "Hello World" > abc/def.txt
-      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+      - uses: pedroaston/assert-command-line-output@workdir_feature
         with:
           command_line: cat def.txt
           contains: Goodbye

--- a/.github/workflows/macos_test_command_output_feature.yml
+++ b/.github/workflows/macos_test_command_output_feature.yml
@@ -1,0 +1,94 @@
+name: Action test on MacOs
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  PASSED-assert-file:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat action.yml
+          assert_file_path: action.yml
+          expected_result: PASSED
+
+  FAILED-assert-file:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          assert_file_path: assert.txt
+          expected_result: FAILED
+
+  PASSED-specific-line:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat action.yml
+          assert_file_path: action.yml
+          expected_result: PASSED
+          specific_line: 1
+
+  FAILED-specific-line:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          assert_file_path: assert.txt
+          expected_result: FAILED
+          specific_line: 2
+
+  PASSED-contains:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          contains: runner
+          expected_result: PASSED
+
+  FAILED-contains:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          contains: error
+          expected_result: FAILED
+
+  PASSED-work-dir:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: mkdir abc
+      - run: echo "Hello World" > abc/def.txt
+      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat def.txt
+          contains: Hello
+          work_dir: abc
+          expected_result: PASSED
+
+  FAILED-work-dir:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: mkdir abc
+      - run: echo "Hello World" > abc/def.txt
+      - uses: GuillaumeFalourd/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat def.txt
+          contains: Goodbye
+          work_dir: abc
+          expected_result: FAILED

--- a/.github/workflows/macos_test_command_output_v2.yml
+++ b/.github/workflows/macos_test_command_output_v2.yml
@@ -1,4 +1,4 @@
-name: Action test on MacOs
+name: Action test on MacOs (V2)
 
 on:
   push:

--- a/.github/workflows/macos_test_command_output_v2.yml
+++ b/.github/workflows/macos_test_command_output_v2.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -29,7 +29,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -51,7 +51,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           contains: runner
@@ -61,7 +61,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           contains: error
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: mkdir abc
       - run: echo "Hello World" > abc/def.txt
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat def.txt
           contains: Hello
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: mkdir abc
       - run: echo "Hello World" > abc/def.txt
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat def.txt
           contains: Goodbye

--- a/.github/workflows/ubuntu_test_command_output_v2.yml
+++ b/.github/workflows/ubuntu_test_command_output_v2.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           contains: runner
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           contains: error
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: mkdir abc
       - run: echo "Hello World" > abc/def.txt
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat def.txt
           contains: Hello
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: mkdir abc
       - run: echo "Hello World" > abc/def.txt
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat def.txt
           contains: Goodbye

--- a/.github/workflows/ubuntu_test_command_output_v2.yml
+++ b/.github/workflows/ubuntu_test_command_output_v2.yml
@@ -1,0 +1,94 @@
+name: Action test on Ubuntu (V2)
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  PASSED-assert-file:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat action.yml
+          assert_file_path: action.yml
+          expected_result: PASSED
+
+  FAILED-assert-file:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          assert_file_path: assert.txt
+          expected_result: FAILED
+
+  PASSED-specific-line:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat action.yml
+          assert_file_path: action.yml
+          expected_result: PASSED
+          specific_line: 1
+
+  FAILED-specific-line:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          assert_file_path: assert.txt
+          expected_result: FAILED
+          specific_line: 2
+
+  PASSED-contains:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          contains: runner
+          expected_result: PASSED
+
+  FAILED-contains:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          contains: error
+          expected_result: FAILED
+
+  PASSED-work-dir:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: mkdir abc
+      - run: echo "Hello World" > abc/def.txt
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat def.txt
+          contains: Hello
+          work_dir: abc
+          expected_result: PASSED
+
+  FAILED-work-dir:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: mkdir abc
+      - run: echo "Hello World" > abc/def.txt
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat def.txt
+          contains: Goodbye
+          work_dir: abc
+          expected_result: FAILED

--- a/.github/workflows/windows_test_command_output_v2.yml
+++ b/.github/workflows/windows_test_command_output_v2.yml
@@ -1,0 +1,94 @@
+name: Action test on Windows (V2)
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  PASSED-assert-file:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat action.yml
+          assert_file_path: action.yml
+          expected_result: PASSED
+
+  FAILED-assert-file:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          assert_file_path: assert.txt
+          expected_result: FAILED
+
+  PASSED-specific-line:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat action.yml
+          assert_file_path: action.yml
+          expected_result: PASSED
+          specific_line: 1
+
+  FAILED-specific-line:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          assert_file_path: assert.txt
+          expected_result: FAILED
+          specific_line: 2
+
+  PASSED-contains:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          contains: runner
+          expected_result: PASSED
+
+  FAILED-contains:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: ls -lha
+          contains: error
+          expected_result: FAILED
+
+  PASSED-work-dir:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: mkdir abc
+      - run: echo "Hello World" > abc/def.txt
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat def.txt
+          contains: Hello
+          work_dir: abc
+          expected_result: PASSED
+
+  FAILED-work-dir:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: mkdir abc
+      - run: echo "Hello World" > abc/def.txt
+      - uses: pedroaston/assert-command-line-output@workdir_feature
+        with:
+          command_line: cat def.txt
+          contains: Goodbye
+          work_dir: abc
+          expected_result: FAILED

--- a/.github/workflows/windows_test_command_output_v2.yml
+++ b/.github/workflows/windows_test_command_output_v2.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -29,7 +29,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat action.yml
           assert_file_path: action.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           assert_file_path: assert.txt
@@ -51,7 +51,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           contains: runner
@@ -61,7 +61,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: ls -lha
           contains: error
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: mkdir abc
       - run: echo "Hello World" > abc/def.txt
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat def.txt
           contains: Hello
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: mkdir abc
       - run: echo "Hello World" > abc/def.txt
-      - uses: pedroaston/assert-command-line-output@workdir_feature
+      - uses: ./
         with:
           command_line: cat def.txt
           contains: Goodbye

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
     contains:
         description: 'Expression the command line output file must contain'
         required: false
+    work_dir:
+        description: 'Path to run the command and respective assertion'
+        required: false
     expected_result:
         description: 'PASSED or FAILED'
         required: false
@@ -45,7 +48,9 @@ runs:
       run: |
         ${{ inputs.command_line }} &> output.txt || true
         echo 🚀 Command OUTPUT exported to output.txt file
+      working-directory: ${{ inputs.work_dir }}
       shell: bash
+      
 
     - name: Assert
       id: assert
@@ -73,6 +78,7 @@ runs:
             fi
         fi
         echo "result=$(echo $result)" >> $GITHUB_OUTPUT
+      working-directory: ${{ inputs.work_dir }}
       shell: bash
 
     - name: GOT vs EXPECTED
@@ -93,6 +99,7 @@ runs:
         else
             echo 🆚 GOT = EXPECTED ✅
         fi
+      working-directory: ${{ inputs.work_dir }}
       shell: bash
 
 branding:


### PR DESCRIPTION
Hey! I've modified the action to be able to receive the input "work_dir" and use its value has the working-directory of all the run steps of the action.yml. I created *v2.yml workflows to validate with 2 additional cases to validate this feature. The naming of the input can be change if preferred.

We could also update the README table with the new input. I'm open for anything else 😃   

This closes #11 